### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ npm run dev
 ```sh
 npm run build
 ```
+
+## Automatic Deployment
+
+Pushing changes to the `main` branch triggers a GitHub Actions workflow that
+builds the project and deploys the contents of `dist` to GitHub Pages.
+Enable GitHub Pages for your repository to have updates deployed automatically.


### PR DESCRIPTION
## Summary
- deploy on push to `main` using GitHub Actions
- document automatic deployment in the README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68416dd459148320b27ebf4d199031b9